### PR TITLE
Fixed reference file function indexing to point to the name of output file instead of MSA c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,16 +281,22 @@ indicated at the ```PTT_config.cfg``` file with the variable ```working_director
 output fits files of intermediary products will also be saved in the working directory. 
 In the terminal type:
 ```bash
-pytest -s --config_file=PTT_config.cfg --html=report.html --self-contained-html
+pytest -s --config_file=PTT_config.cfg --self-contained-html
 ```
 The ```-s``` will capture all the print statements in the code on screen. If you want to
 save the on-screen output into a text file simply do:
 ```bash
-pytest -s --config_file=PTT_config.cfg --html=report.html --self-contained-html 
-                                                                      > screen_output.txt
+pytest -s --config_file=PTT_config.cfg --self-contained-html > screen_output.txt
 ```
 and this will create the ```screen_output.txt``` file in the ```calweb_spec2_pytests``` 
 directory, and at the end this file will also be moved to the working directory.
+If you want the html report in any other directory, then you need to specify the location 
+with the flagg ```--html=/desired_new_path/report.html```, e.g.
+```bash
+pytest -s --config_file=PTT_config.cfg --html=report.html --self-contained-html
+```
+will create the report in the directory where the pytests are being run, the the 
+```calweb_spec2_pytests``` directory.
 
 
 10. Report your findings. If all went well, you should have the html report in the 

--- a/calwebb_spec2_pytests/B_bkg_subtract/test_bkg_subtract.py
+++ b/calwebb_spec2_pytests/B_bkg_subtract/test_bkg_subtract.py
@@ -57,7 +57,7 @@ def output_hdul(set_inandout_filenames, config):
         step_output_file = os.path.join(working_directory, local_step_output_file)
         print ("Step product was saved as: ", step_output_file)
         subprocess.run(["mv", local_step_output_file, step_output_file])
-        return hdul
+        return hdul, step_output_file, step_input_file
     else:
         if config.getboolean("steps", step):
             print ("*** Step "+step+" set to True")
@@ -95,7 +95,7 @@ def output_hdul(set_inandout_filenames, config):
                         hdul = core_utils.read_hdrfits(step_output_file, info=False, show_hdr=False)
                         step_completed = True
                     core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
-                    return hdul, step_input_file
+                    return hdul, step_output_file, step_input_file
             else:
                 print (" The input file does not exist. Skipping step.")
                 core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)

--- a/calwebb_spec2_pytests/C_imprint_subtract/test_imprint_subtract.py
+++ b/calwebb_spec2_pytests/C_imprint_subtract/test_imprint_subtract.py
@@ -63,7 +63,7 @@ def output_hdul(set_inandout_filenames, config):
             step_output_file = os.path.join(working_directory, local_step_output_file)
             print ("Step product was saved as: ", step_output_file)
             subprocess.run(["mv", local_step_output_file, step_output_file])
-            return hdul, run_step, step_input_file, step_output_file
+            return hdul, step_output_file, run_step, step_input_file
         else:
             if run_step:
                 print ("*** Step "+step+" set to True")
@@ -99,7 +99,7 @@ def output_hdul(set_inandout_filenames, config):
                             hdul = core_utils.read_hdrfits(step_output_file, info=False, show_hdr=False)
                             step_completed = True
                         core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
-                        return hdul, run_step, step_input_file, step_output_file
+                        return hdul, step_output_file, run_step, step_input_file
                 else:
                     core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
                     pytest.skip("Skipping "+step+" because the input file does not exist.")
@@ -116,9 +116,9 @@ def output_hdul(set_inandout_filenames, config):
 # fixture to validate the subtraction works fine: re-run the step with the same file as msa_imprint file
 @pytest.fixture(scope="module")
 def check_output_is_zero(output_hdul):
-    run_step = output_hdul[1]
-    step_input_file = output_hdul[2]
-    step_output_file = output_hdul[3]
+    run_step = output_hdul[2]
+    step_input_file = output_hdul[3]
+    step_output_file = output_hdul[1]
     # Only run test if data is IFU or MSA
     inhdu = core_utils.read_hdrfits(step_input_file, info=False, show_hdr=False)
     if core_utils.check_IFU_true(inhdu) or core_utils.check_MOS_true(inhdu):

--- a/calwebb_spec2_pytests/D_msa_flagging/test_msa_flagging.py
+++ b/calwebb_spec2_pytests/D_msa_flagging/test_msa_flagging.py
@@ -56,7 +56,7 @@ def output_hdul(set_inandout_filenames, config):
             step_output_file = os.path.join(working_directory, local_step_output_file)
             print ("Step product was saved as: ", step_output_file)
             subprocess.run(["mv", local_step_output_file, step_output_file])
-            return hdul
+            return hdul, step_output_file
         else:
             if config.getboolean("steps", step):
                 print ("*** Step "+step+" set to True")
@@ -76,7 +76,7 @@ def output_hdul(set_inandout_filenames, config):
                     step_completed = True
                     core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
                     hdul = core_utils.read_hdrfits(step_output_file, info=False, show_hdr=False)
-                    return hdul
+                    return hdul, step_output_file
                 else:
                     core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
                     pytest.skip("Skipping "+step+" because the input file does not exist.")
@@ -91,4 +91,4 @@ def output_hdul(set_inandout_filenames, config):
 # Unit tests
 
 def test_msa_failed_open_exists(output_hdul):
-    assert msa_flagging_utils.msa_failed_open_exists(output_hdul), "The keyword S_MSAFLG was not added to the header --> msa_flagging step was not completed."
+    assert msa_flagging_utils.msa_failed_open_exists(output_hdul[0]), "The keyword S_MSAFLG was not added to the header --> msa_flagging step was not completed."

--- a/calwebb_spec2_pytests/F_flat_field/test_flat_field.py
+++ b/calwebb_spec2_pytests/F_flat_field/test_flat_field.py
@@ -83,7 +83,7 @@ def output_hdul(set_inandout_filenames, config):
         subprocess.run(["mv", intflat, intflat_file])
         hdul = core_utils.read_hdrfits(step_output_file, info=False, show_hdr=False)
         flattest_paths = [step_output_file, msa_shutter_conf, dflat_path, sflat_path, fflat_path]
-        return hdul, flattest_paths, flattest_switches
+        return hdul, step_output_file, flattest_paths, flattest_switches
     else:
         if config.getboolean("steps", step):
             print ("*** Step "+step+" set to True")
@@ -125,7 +125,7 @@ def output_hdul(set_inandout_filenames, config):
                 step_completed = True
                 core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
                 hdul = core_utils.read_hdrfits(step_output_file, info=False, show_hdr=False)
-                return hdul, flattest_paths, flattest_switches
+                return hdul, step_output_file, flattest_paths, flattest_switches
             else:
                 core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
                 pytest.skip("Skipping "+step+" because the input file does not exist.")
@@ -142,8 +142,8 @@ def output_hdul(set_inandout_filenames, config):
 def validate_flat_field(output_hdul):
     # get the input information for the wcs routine
     hdu = output_hdul[0]
-    step_output_file, msa_shutter_conf, dflatref_path, sfile_path, fflat_path = output_hdul[1]
-    flattest_threshold_diff, save_flattest_plot, write_flattest_files = output_hdul[2]
+    step_output_file, msa_shutter_conf, dflatref_path, sfile_path, fflat_path = output_hdul[2]
+    flattest_threshold_diff, save_flattest_plot, write_flattest_files = output_hdul[3]
 
     # show the figures
     show_figs = False

--- a/calwebb_spec2_pytests/G_srctype/test_srctype.py
+++ b/calwebb_spec2_pytests/G_srctype/test_srctype.py
@@ -63,7 +63,7 @@ def output_hdul(set_inandout_filenames, config):
         local_step_output_file = os.path.join(working_directory, local_step_output_file)
         hdul = core_utils.read_hdrfits(local_step_output_file, info=False, show_hdr=False)
         print ("Step srctype does not produce an output product.")
-        return hdul
+        return hdul, step_output_file
     else:
         # only run this step if data is not BOTS
         inhdu = core_utils.read_hdrfits(step_input_file, info=False, show_hdr=False)
@@ -87,7 +87,7 @@ def output_hdul(set_inandout_filenames, config):
                     step_completed = True
                     core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
                     hdul = core_utils.read_hdrfits(step_output_file, info=False, show_hdr=False)
-                    return hdul
+                    return hdul, step_output_file
                 else:
                     core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
                     pytest.skip("Skipping "+step+" because the input file does not exist.")
@@ -102,5 +102,5 @@ def output_hdul(set_inandout_filenames, config):
 # Unit tests
 
 def test_s_srctype_exists(output_hdul):
-    assert srctype_utils.s_srctype_exists(output_hdul), "The keyword SRCTYPE was not added to the header --> Srctype step was not completed."
+    assert srctype_utils.s_srctype_exists(output_hdul[0]), "The keyword SRCTYPE was not added to the header --> Srctype step was not completed."
 

--- a/calwebb_spec2_pytests/H_pathloss/test_pathloss.py
+++ b/calwebb_spec2_pytests/H_pathloss/test_pathloss.py
@@ -66,7 +66,7 @@ def output_hdul(set_inandout_filenames, config):
         step_output_file = os.path.join(working_directory, local_step_output_file)
         print ("Step product was saved as: ", step_output_file)
         subprocess.run(["mv", local_step_output_file, step_output_file])
-        return hdul
+        return hdul, step_output_file
     else:
         # only run this step if data is not BOTS
         inhdu = core_utils.read_hdrfits(step_input_file, info=False, show_hdr=False)
@@ -90,7 +90,7 @@ def output_hdul(set_inandout_filenames, config):
                     step_completed = True
                     core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
                     hdul = core_utils.read_hdrfits(step_output_file, info=False, show_hdr=False)
-                    return hdul
+                    return hdul, step_output_file
                 else:
                     core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
                     pytest.skip("Skipping "+step+" because the input file does not exist.")
@@ -105,10 +105,10 @@ def output_hdul(set_inandout_filenames, config):
 # Unit tests
 
 def test_s_pthlos_exists(output_hdul):
-    assert pathloss_utils.s_pthlos_exists(output_hdul), "The keyword S_PTHLOS was not added to the header --> Pathloss step was not completed."
+    assert pathloss_utils.s_pthlos_exists(output_hdul[0]), "The keyword S_PTHLOS was not added to the header --> Pathloss step was not completed."
 
 def test_r_pthlos_exists(output_hdul):
-    assert pathloss_utils.r_pthlos_exists(output_hdul), "The keyword R_PTHLOS was not added to the header --> Not sure what reference file was used."
+    assert pathloss_utils.r_pthlos_exists(output_hdul[0]), "The keyword R_PTHLOS was not added to the header --> Not sure what reference file was used."
 
 def test_pthlos_rfile(output_hdul):
     result = pathloss_utils.pthlos_rfile_is_correct(output_hdul)

--- a/calwebb_spec2_pytests/I_barshadow/test_barshadow.py
+++ b/calwebb_spec2_pytests/I_barshadow/test_barshadow.py
@@ -69,7 +69,7 @@ def output_hdul(set_inandout_filenames, config):
             step_output_file = os.path.join(working_directory, local_step_output_file)
             print ("Step product was saved as: ", step_output_file)
             subprocess.run(["mv", local_step_output_file, step_output_file])
-            return hdul
+            return hdul, step_output_file
         else:
             if config.getboolean("steps", step):
                 print ("*** Step "+step+" set to True")
@@ -90,7 +90,7 @@ def output_hdul(set_inandout_filenames, config):
                     step_completed = True
                     core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
                     hdul = core_utils.read_hdrfits(step_output_file, info=False, show_hdr=False)
-                    return hdul
+                    return hdul, step_output_file
                 else:
                     core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
                     pytest.skip("Skipping "+step+" because the input file does not exist.")
@@ -105,5 +105,5 @@ def output_hdul(set_inandout_filenames, config):
 # Unit tests
 
 def test_s_barsha_exists(output_hdul):
-    assert barshadow_utils.s_barsha_exists(output_hdul), "The keyword S_BARSHA was not added to the header --> Barshadow step was not completed."
+    assert barshadow_utils.s_barsha_exists(output_hdul[0]), "The keyword S_BARSHA was not added to the header --> Barshadow step was not completed."
 

--- a/calwebb_spec2_pytests/J_photom/test_photom.py
+++ b/calwebb_spec2_pytests/J_photom/test_photom.py
@@ -66,7 +66,7 @@ def output_hdul(set_inandout_filenames, config):
         step_output_file = os.path.join(working_directory, local_step_output_file)
         print ("Step product was saved as: ", step_output_file)
         subprocess.run(["mv", local_step_output_file, step_output_file])
-        return hdul
+        return hdul, step_output_file
     else:
         if config.getboolean("steps", step):
             print ("*** Step "+step+" set to True")
@@ -87,7 +87,7 @@ def output_hdul(set_inandout_filenames, config):
                 step_completed = True
                 core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
                 hdul = core_utils.read_hdrfits(step_output_file, info=False, show_hdr=False)
-                return hdul
+                return hdul, step_output_file
             else:
                 core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
                 pytest.skip("Skipping "+step+" because the input file does not exist.")
@@ -100,5 +100,5 @@ def output_hdul(set_inandout_filenames, config):
 # Unit tests
 
 def test_s_photom_exists(output_hdul):
-    assert photom_utils.s_photom_exists(output_hdul), "The keyword S_PHOTOM was not added to the header --> Photom step was not completed."
+    assert photom_utils.s_photom_exists(output_hdul[0]), "The keyword S_PHOTOM was not added to the header --> Photom step was not completed."
 

--- a/calwebb_spec2_pytests/K_resample/test_resample.py
+++ b/calwebb_spec2_pytests/K_resample/test_resample.py
@@ -69,7 +69,7 @@ def output_hdul(set_inandout_filenames, config):
             step_output_file = os.path.join(working_directory, local_step_output_file)
             print ("Step product was saved as: ", step_output_file)
             subprocess.run(["mv", local_step_output_file, step_output_file])
-            return hdul
+            return hdul, step_output_file
         else:
             if config.getboolean("steps", step):
                 print ("*** Step "+step+" set to True")
@@ -90,7 +90,7 @@ def output_hdul(set_inandout_filenames, config):
                     step_completed = True
                     core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
                     hdul = core_utils.read_hdrfits(step_output_file, info=False, show_hdr=False)
-                    return hdul
+                    return hdul, step_output_file
                 else:
                     core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
                     pytest.skip("Skipping "+step+" because the input file does not exist.")
@@ -105,5 +105,5 @@ def output_hdul(set_inandout_filenames, config):
 # Unit tests
 
 def test_s_resample_exists(output_hdul):
-    assert resample_utils.s_resamp_exists(output_hdul), "The keyword S_RESAMP was not added to the header --> Resample step was not completed."
+    assert resample_utils.s_resamp_exists(output_hdul[0]), "The keyword S_RESAMP was not added to the header --> Resample step was not completed."
 

--- a/calwebb_spec2_pytests/L_cube_build/test_cube_build.py
+++ b/calwebb_spec2_pytests/L_cube_build/test_cube_build.py
@@ -70,7 +70,7 @@ def output_hdul(set_inandout_filenames, config):
             step_output_file = os.path.join(working_directory, local_step_output_file)
             print ("Step product was saved as: ", step_output_file)
             subprocess.run(["mv", local_step_output_file, step_output_file])
-            return hdul
+            return hdul, step_output_file
         else:
             if config.getboolean("steps", step):
                 print ("*** Step "+step+" set to True")
@@ -98,7 +98,7 @@ def output_hdul(set_inandout_filenames, config):
                     step_completed = True
                     core_utils.add_completed_steps(txt_name, step, "_"+cube_suffix, step_completed, end_time)
                     hdul = core_utils.read_hdrfits(specific_output_file, info=False, show_hdr=False)
-                    return hdul
+                    return hdul, step_output_file
                 else:
                     core_utils.add_completed_steps(txt_name, step, outstep_file_suffix, step_completed, end_time)
                     pytest.skip("Skipping "+step+" because the input file does not exist.")
@@ -113,5 +113,5 @@ def output_hdul(set_inandout_filenames, config):
 # Unit tests
 
 def test_s_ifucub_exists(output_hdul):
-    assert cube_build_utils.s_ifucub_exists(output_hdul), "The keyword S_IFUCUB was not added to the header --> IFU cube_build step was not completed."
+    assert cube_build_utils.s_ifucub_exists(output_hdul[0]), "The keyword S_IFUCUB was not added to the header --> IFU cube_build step was not completed."
 

--- a/calwebb_spec2_pytests/PTT_config.cfg
+++ b/calwebb_spec2_pytests/PTT_config.cfg
@@ -12,35 +12,33 @@
 # local_pipe_cfg_path = path to the configuration files, if pipe_source_tree_code, will use default config files
 [calwebb_spec2_input_file]
 pipe_testing_tool_path = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/nirspec_pipe_testing_tool
-working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part1_JanuaryDeadline/IFU_CV3/PRISM_CLEAR/pipe_testing_files_and_reports/6007022859_491_processing
+#working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part1_JanuaryDeadline/IFU_CV3/PRISM_CLEAR/pipe_testing_files_and_reports/6007022859_491_processing
 #working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part1_JanuaryDeadline/IFU_CV3/G140M_F100LP/pipe_testing_files_and_reports/491_processing
 #working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/MOS_James/NRSV96215001001P0000000002103_1_491_results
-#working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part2/FS_ALLSLITS/G140M_F070LP/491_results
+working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part2/FS_ALLSLITS/G235M_F170LP/491_results/
 #working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part2/FS_FULL_FRAME/G140H_opaque/491_results
 #working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part2/BOTS/491_results
 #data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part1_JanuaryDeadline/IFU_CV3/G140M_F100LP/pipe_testing_files_and_reports/491_processing
-data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part1_JanuaryDeadline/IFU_CV3/PRISM_CLEAR/pipe_testing_files_and_reports/6007022859_491_processing
+#data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part1_JanuaryDeadline/IFU_CV3/PRISM_CLEAR/pipe_testing_files_and_reports/6007022859_491_processing
 #data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/MOS_James/NRSV96215001001P0000000002103_1_491_results
-#data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part2/FS_ALLSLITS/G140M_F070LP/491_results
+data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part2/FS_ALLSLITS/G235M_F170LP/491_results/
 #data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part2/FS_FULL_FRAME/G140H_opaque/491_results
 #data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part2/BOTS/491_results
 # name of the suffix map (will be saved in the pytests directory)
 True_steps_suffix_map = True_steps_suffix_map.txt
 #input_file = jwdata0010010_11010_0001_NRS1_uncal_rate.fits
 input_file = gain_scale.fits
-mode_used = IFU
+mode_used = FS
 change_filter_opaque = False
 # Name of the raw data file used for create_data
 # IFU 
 #raw_data_root_file = NRSSRAD-G2H-PS-6007132838_1_491_SE_2016-01-07T17h03m08.fits
 # IFU prism
-raw_data_root_file = NRSSIMA-QUAL-04-B-6007022859_1_491_SE_2016-01-07T02h37m13.fits
+#raw_data_root_file = NRSSIMA-QUAL-04-B-6007022859_1_491_SE_2016-01-07T02h37m13.fits
 # MOS
 #raw_data_root_file = NRSV96215001001P0000000002103_1_491_SE_2016-01-24T01h25m07.fits
 # FS
-#raw_data_root_file = NRSV84600002001P0000000002101_1_491_SE_2016-01-17T15h09m16.fits
-#raw_data_root_file = NRSV84600010001P0000000002101_4_491_SE_2016-01-17T17h34m08.fits
-#raw_data_root_file = NRSSMOS-MOD-G1H-02-5344031756_1_491_SE_2015-12-10T03h25m56.fits
+raw_data_root_file = NRSV84600004001P0000000002102_1_491_SE_2016-01-17T15h47m57.fits
 # BOTS
 #raw_data_root_file = NRSSRAD-G2H-PS-6007132838_1_491_SE_2016-01-07T17h03m08.fits
 # local path for pipeline configuration files
@@ -49,22 +47,23 @@ local_pipe_cfg_path = pipe_source_tree_code
 
 # Full path of where to find all ESA intermediary products to make comparisons for the tests and other reference files
 [esa_intermediary_products]
-esa_files_path = /grp/jwst/wit4/nirspec_vault/prelaunch_data/testing_sets/b7.1_pipeline_testing/test_data_suite/IFU_CV3/ESA_Int_products
-#esa_files_path = /grp/jwst/wit4/nirspec_vault/prelaunch_data/testing_sets/b7.1_pipeline_testing/test_data_suite/FS_CV3/ESA_Int_products
+#esa_files_path = /grp/jwst/wit4/nirspec_vault/prelaunch_data/testing_sets/b7.1_pipeline_testing/test_data_suite/IFU_CV3/ESA_Int_products
+esa_files_path = /grp/jwst/wit4/nirspec_vault/prelaunch_data/testing_sets/b7.1_pipeline_testing/test_data_suite/FS_CV3/ESA_Int_products
 #esa_files_path = /grp/jwst/wit4/nirspec_vault/prelaunch_data/testing_sets/b7.1_pipeline_testing/test_data_suite/FS_CV3_cutouts/ESA_Int_products
 #esa_files_path = /grp/jwst/wit4/nirspec_vault/prelaunch_data/testing_sets/b7.1_pipeline_testing/test_data_suite/MOS_CV3/ESA_Int_products
 # if msa data is not used, the msa_conf_name variable is irrelevant and will not be read
-msa_conf_name = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/MOS_James/NRSV96215001001P0000000002103_1_491_results/V9621500100101_short_msa.fits
+msa_conf_name = /path_to_corresponding_MSA_shutter_configuration_file/V9621500100101_short_msa.fits
+#msa_conf_name = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/MOS_James/NRSV96215001001P0000000002103_1_491_results/V9621500100101_short_msa.fits
 dflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.2_D_Flat/nirspec_dflat
 #dflat_path = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/zzzz/nirspec_dflat
 #sflat_path = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/zzzz/nirspec_MOS_sflat
 #fflat_path = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/zzzz/nirspec_MOS_fflat
 #sflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.3_S_Flat/MOS/nirspec_MOS_sflat
 #fflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.1_F_Flat/MOS/nirspec_MOS_fflat
-#sflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.3_S_Flat/FS/nirspec_FS_sflat
-#fflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.1_F_Flat/FS/nirspec_FS_fflat
-sflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.3_S_Flat/IFU/nirspec_IFU_sflat
-fflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.1_F_Flat/IFU/nirspec_IFU_fflat
+sflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.3_S_Flat/FS/nirspec_FS_sflat
+fflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.1_F_Flat/FS/nirspec_FS_fflat
+#sflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.3_S_Flat/IFU/nirspec_IFU_sflat
+#fflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.1_F_Flat/IFU/nirspec_IFU_fflat
 
 # switch to run calwebb_spec2 in full
 # If this option is set to True, the full path of the configuration file must be provided and

--- a/calwebb_spec2_pytests/auxiliary_code/flattest_fs.py
+++ b/calwebb_spec2_pytests/auxiliary_code/flattest_fs.py
@@ -169,12 +169,11 @@ def flattest(step_input_filename, dflatref_path=None, sfile_path=None, fflat_pat
         print("np.shape(sfim) = ", np.shape(sfim))
         print("np.shape(sfimdq) = ", np.shape(sfimdq))
 
-    if det == "NRS1":
-        sfv_a2001 = fits.getdata(sfile, "SLIT_A_200_1")#5)
-        sfv_a2002 = fits.getdata(sfile, "SLIT_A_200_2")#6)
-        sfv_a400 = fits.getdata(sfile, "SLIT_A_400")#7)
-        sfv_a1600 = fits.getdata(sfile, "SLIT_A_1600")#8)
-    elif det == "NRS2":
+    sfv_a2001 = fits.getdata(sfile, "SLIT_A_200_1")#5)
+    sfv_a2002 = fits.getdata(sfile, "SLIT_A_200_2")#6)
+    sfv_a400 = fits.getdata(sfile, "SLIT_A_400")#7)
+    sfv_a1600 = fits.getdata(sfile, "SLIT_A_1600")#8)
+    if det == "NRS2":
         sfv_b200 = fits.getdata(sfile, "SLIT_B_200")#5)
 
     # F-Flat

--- a/calwebb_spec2_pytests/auxiliary_code/reffile_test.py
+++ b/calwebb_spec2_pytests/auxiliary_code/reffile_test.py
@@ -211,7 +211,7 @@ def create_rfile_test(step, doc_insert):
     """
     
     def rfile_test_step(output_hdul):
-        output_file = output_hdul[2]
+        output_file = output_hdul[1]
         return reffile_test(output_file, step)
     
     rfile_test_step.__doc__ = """

--- a/calwebb_spec2_pytests/conftest.py
+++ b/calwebb_spec2_pytests/conftest.py
@@ -31,7 +31,13 @@ def pytest_addoption(parser):
 def config(request):
     config = configparser.ConfigParser()
     config.read(request.config.getoption("--config_file"))
+    # place the report in the working directory unless otherwise specified
+    config.read(['../calwebb_spec2_pytests/PTT_config.cfg'])
+    working_dir = config.get("calwebb_spec2_input_file", "working_directory")
+    request.htmlpath = request.config.getoption('htmlpath', working_dir+"/report.html")
+    config.read(request.config.getoption("--config_file"))
     return config
+
 
 """
 @pytest.mark.hookwrapper


### PR DESCRIPTION
…onfig file, and added the output name in all steps as the second item in the list. Also fixed issue with flat-field calculation for FS with NRS2, but still giving errors of array full of outliers.
@gkanarek, I found that almost all the reference file checks where giving error of file not found. The file it was looking for was the MSA shutter configuration file, regardless of mode. This was because the index of the output was pointing to this file instead of the name of the step output file. Also, most of the steps only had as output the header as a dictionary, so I added the output file name as the second argument for all steps.