### PR TITLE
Fix `get_sci_extensions`

### DIFF
--- a/calwebb_spec2_pytests/auxiliary_code/auxiliary_functions.py
+++ b/calwebb_spec2_pytests/auxiliary_code/auxiliary_functions.py
@@ -49,11 +49,11 @@ def get_sci_extensions(fits_file_name):
     """
     hdulist = fits.open(fits_file_name)
     hdulist.info()
-    sci_list = []
+    sci_dict = {}
     for ext, hdu in enumerate(hdulist):
         if hdu.name == "SCI":
-            sci_list.append(ext)
-    return sci_list
+            sci_dict[hdu.header["SLTNAME"]] = ext
+    return sci_dict
 
 
 def do_idl_match(arrA, arrB):

--- a/calwebb_spec2_pytests/auxiliary_code/flattest_mos.py
+++ b/calwebb_spec2_pytests/auxiliary_code/flattest_mos.py
@@ -234,7 +234,7 @@ def flattest(step_input_filename, dflatref_path=None, sfile_path=None, fflat_pat
     for slit in model.slits:
         slit_id = slit.name
         print ("\nWorking with slit: ", slit_id)
-        ext = sci_ext_list.index(int(slit_id))   # this is for getting the science extension in the pipeline calculated flat
+        ext = sci_ext_list[slit_id]   # this is for getting the science extension in the pipeline calculated flat
         # make sure that the slitlet is open and projected on the detector, otherwise indicate so
         #if not slit_id in open_and_on_detector_slits_list:
         #    print("* This open slitlet was removed because it is not projected on the detector. Test skipped for this slitlet. \n")

--- a/calwebb_spec2_pytests/core_utils.py
+++ b/calwebb_spec2_pytests/core_utils.py
@@ -121,7 +121,7 @@ def get_sci_extensions(fits_file_name):
     sci_dicts = {}
     for ext, hdu in enumerate(hdulist):
         if hdu.name == "SCI":
-            sci_list[hdu.header['SLTNAME'] = ext
+            sci_list[hdu.header['SLTNAME']] = ext
     return sci_list
 
 

--- a/calwebb_spec2_pytests/core_utils.py
+++ b/calwebb_spec2_pytests/core_utils.py
@@ -118,10 +118,10 @@ def get_sci_extensions(fits_file_name):
         sci_list: list of the numbers of the science extensions
     """
     hdulist = fits.open(fits_file_name)
-    sci_list = []
+    sci_dicts = {}
     for ext, hdu in enumerate(hdulist):
         if hdu.name == "SCI":
-            sci_list.append(ext)
+            sci_list[hdu.header['SLTNAME'] = ext
     return sci_list
 
 


### PR DESCRIPTION
The `get_sci_extensions` function only tracks which extensions are SCI but not which slit is associated with each SCI extension, which is not ideal. Now, the function returns a dictionary where the keys are slit names and the values are the associated extension numbers.

Any code which uses this function still needs to be updated to use the new return type. Please don't merge this branch until it's done!