### PR TITLE
Fix pytest4 deprecation error

### DIFF
--- a/calwebb_spec2_pytests/A_assign_wcs/test_assign_wcs.py
+++ b/calwebb_spec2_pytests/A_assign_wcs/test_assign_wcs.py
@@ -544,6 +544,6 @@ def test_validate_wcs(output_hdul, request):
     else:
         print("\n", validate_wcs, "\n")
         print("\n * Running validation pytest...\n")
-        assert request.getfixturevalue(validate_wcs), "Output value from compare_wcs.py is greater than threshold."
+        assert request.getfixturevalue('validate_wcs'), "Output value from compare_wcs.py is greater than threshold."
 
 

--- a/calwebb_spec2_pytests/A_assign_wcs/test_assign_wcs.py
+++ b/calwebb_spec2_pytests/A_assign_wcs/test_assign_wcs.py
@@ -534,7 +534,7 @@ def test_s_wcs_exists(output_hdul):
         print("\n * Running completion pytest...\n")
         assert assign_wcs_utils.s_wcs_exists(output_hdul[0]), "The keyword S_WCS was not added to the header --> extract_2d step was not completed."
 
-def test_validate_wcs(output_hdul, validate_wcs):
+def test_validate_wcs(output_hdul, request):
     # want to run this pytest?
     run_pytests = output_hdul[6]
     if not run_pytests:
@@ -542,7 +542,8 @@ def test_validate_wcs(output_hdul, validate_wcs):
         print(msg)
         pytest.skip(msg)
     else:
+        print("\n", validate_wcs, "\n")
         print("\n * Running validation pytest...\n")
-        assert validate_wcs(output_hdul), "Output value from compare_wcs.py is greater than threshold."
+        assert request.getfixturevalue(validate_wcs), "Output value from compare_wcs.py is greater than threshold."
 
 

--- a/calwebb_spec2_pytests/A_assign_wcs/test_assign_wcs.py
+++ b/calwebb_spec2_pytests/A_assign_wcs/test_assign_wcs.py
@@ -534,7 +534,7 @@ def test_s_wcs_exists(output_hdul):
         print("\n * Running completion pytest...\n")
         assert assign_wcs_utils.s_wcs_exists(output_hdul[0]), "The keyword S_WCS was not added to the header --> extract_2d step was not completed."
 
-def test_validate_wcs(output_hdul):
+def test_validate_wcs(output_hdul, validate_wcs):
     # want to run this pytest?
     run_pytests = output_hdul[6]
     if not run_pytests:

--- a/calwebb_spec2_pytests/C_imprint_subtract/test_imprint_subtract.py
+++ b/calwebb_spec2_pytests/C_imprint_subtract/test_imprint_subtract.py
@@ -166,7 +166,7 @@ def test_s_imprint_exists(output_hdul):
         print("\n * Running completion pytest...\n")
         assert imprint_subtract_utils.s_imprint_exists(output_hdul[0]), "The keyword S_IMPRINT was not added to the header --> imprint_subtract step was not completed."
 
-def test_check_output_is_zero(output_hdul):
+def test_check_output_is_zero(output_hdul, request):
     # want to run this pytest?
     run_pytests = output_hdul[4]
     if not run_pytests:
@@ -175,4 +175,4 @@ def test_check_output_is_zero(output_hdul):
         pytest.skip(msg)
     else:
         print("\n * Running numerical accuracy pytest...\n")
-        assert check_output_is_zero(output_hdul), "Substraction result is not equal to zero."
+        assert request.getfixturevalue('check_output_is_zero'), "Substraction result is not equal to zero."

--- a/calwebb_spec2_pytests/E_extract_2d/test_extract_2d.py
+++ b/calwebb_spec2_pytests/E_extract_2d/test_extract_2d.py
@@ -150,7 +150,7 @@ def test_s_ext2d_exists(output_hdul):
         assert extract_2d_utils.s_ext2d_exists(output_hdul[0]), "The keyword S_EXTR2D was not added to the header --> extract_2d step was not completed."
 
 
-def test_validate_wcs_extract2d(output_hdul):
+def test_validate_wcs_extract2d(output_hdul, validate_wcs_extract2d):
     # want to run this pytest? For this particular case, check both for the extract_2d step and for assign_wcs
     run_pytests = output_hdul[4]
     assign_wcs_pytests = output_hdul[8]

--- a/calwebb_spec2_pytests/E_extract_2d/test_extract_2d.py
+++ b/calwebb_spec2_pytests/E_extract_2d/test_extract_2d.py
@@ -160,4 +160,4 @@ def test_validate_wcs_extract2d(output_hdul, validate_wcs_extract2d):
         pytest.skip(msg)
     else:
        print("\n * Running validation pytest...\n")
-       assert validate_wcs_extract2d(output_hdul), "Output value from compare_wcs.py is greater than threshold."
+       assert request.getfixturevalue('validate_wcs_extract2d'), "Output value from compare_wcs.py is greater than threshold."

--- a/calwebb_spec2_pytests/F_flat_field/test_flat_field.py
+++ b/calwebb_spec2_pytests/F_flat_field/test_flat_field.py
@@ -192,7 +192,7 @@ def test_s_flat_exists(output_hdul):
         print("\n * Running completion pytest...\n")
         assert flat_field_utils.s_flat_exists(output_hdul[0]), "The keyword S_FLAT was not added to the header --> flat_field step was not completed."
 
-def test_validate_flat_field(output_hdul):
+def test_validate_flat_field(output_hdul, request):
     # want to run this pytest?
     run_pytests = output_hdul[4]
     if not run_pytests:
@@ -201,7 +201,7 @@ def test_validate_flat_field(output_hdul):
         pytest.skip(msg)
     else:
         print("\n * Running validation pytest...\n")
-        assert validate_flat_field(output_hdul), "Output value from flattest.py is greater than threshold."
+        assert request.get_fixture_result('validate_flat_field'), "Output value from flattest.py is greater than threshold."
 
 def test_fflat_rfile(output_hdul):
     # want to run this pytest?


### PR DESCRIPTION
This patch is intended to prevent PTT from throwing `RemovedInPytest4Warning` errors due to the tests calling fixtures directly, instead of using `request.get_fixture_result(...)`.