### PR TITLE
changes to flattest_ifu for NRS2

### DIFF
--- a/calwebb_spec2_pytests/PTT_config.cfg
+++ b/calwebb_spec2_pytests/PTT_config.cfg
@@ -16,28 +16,28 @@ pipe_testing_tool_path = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/
 #working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part1_JanuaryDeadline/IFU_CV3/G140M_F100LP/pipe_testing_files_and_reports/491_processing
 #working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/MOS_James/NRSV96215001001P0000000002103_1_491_results
 #working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/MOS_G395M_test
-working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/zzzz/first_run_MOSset
+#working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/zzzz/first_run_MOSset
 #working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/simulation_test/491_results
 #working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part2/FS_ALLSLITS/G235M_F170LP/491_results/
-#working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part2/FS_FULL_FRAME/G140M_opaque/491_results/
+working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part2/FS_FULL_FRAME/G140M_opaque/491_results/
 #working_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part2/BOTS/NRSSRAD-G2H-PS-6007132838_1_491_SE_2016-01-07T17h03m08_491results
 #data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part1_JanuaryDeadline/IFU_CV3/G140M_F100LP/pipe_testing_files_and_reports/491_processing
 #data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part1_JanuaryDeadline/IFU_CV3/PRISM_CLEAR/pipe_testing_files_and_reports/6007022859_491_processing
 #data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/MOS_James/NRSV96215001001P0000000002103_1_491_results
 #data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/MOS_G395M_test
-data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/zzzz/first_run_MOSset
+#data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/zzzz/first_run_MOSset
 #data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/simulation_test/491_results
 #data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part2/FS_ALLSLITS/G235M_F170LP/491_results/
-#data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part2/FS_FULL_FRAME/G140M_opaque/491_results/
+data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part2/FS_FULL_FRAME/G140M_opaque/491_results/
 #data_directory = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/part2/BOTS/NRSSRAD-G2H-PS-6007132838_1_491_SE_2016-01-07T17h03m08_491results
 # name of the suffix map (will be saved in the pytests directory)
 True_steps_suffix_map = True_steps_suffix_map.txt
-input_file = jwtest1010001_01101_00001_NRS1_short.fits
-#input_file = gain_scale.fits
+#input_file = jwtest1010001_01101_00001_NRS1_short.fits
+input_file = gain_scale.fits
 #input_file = g395m_nrs1_gain_scale_F290LP.fits
 #input_file = F170LP-G235M_MOS_observation-6-c0e0_001_DN_NRS1_mod_updatedHDR.fits
 #input_file = final_output_caldet1_NRS1.fits
-mode_used = MOS
+mode_used = FS
 change_filter_opaque = False
 # Name of the raw data file used for create_data
 # IFU 
@@ -47,7 +47,7 @@ change_filter_opaque = False
 # MOS G395M
 #raw_data_root_file = NRSV96215001001P0000000002103_1_491_SE_2016-01-24T01h25m07.fits
 # MOS 
-raw_data_root_file = NRSV96215001001P0000000002103_1_491_SE_2016-01-24T01h25m07.fits
+#raw_data_root_file = NRSV96215001001P0000000002103_1_491_SE_2016-01-24T01h25m07.fits
 # MOS simulation
 #raw_data_root_file = F170LP-G235M_MOS_observation-6-c0e0_001.fits
 # FS
@@ -55,7 +55,7 @@ raw_data_root_file = NRSV96215001001P0000000002103_1_491_SE_2016-01-24T01h25m07.
 # BOTS
 #raw_data_root_file = NRSSRAD-G2H-PS-6007132838_1_491_SE_2016-01-07T17h03m08.fits
 # FS
-#raw_data_root_file = NRSV84600004001P0000000002101_1_491_SE_2016-01-17T15h41m16.fits
+raw_data_root_file = NRSV84600004001P0000000002101_1_491_SE_2016-01-17T15h41m16.fits
 # local path for pipeline configuration files
 #local_pipe_cfg_path = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/build7.1/config_files
 local_pipe_cfg_path = pipe_source_tree_code
@@ -78,10 +78,10 @@ dflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.2_D_Flat/nirspec_dflat
 #dflat_path = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/zzzz/nirspec_dflat
 #sflat_path = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/zzzz/nirspec_MOS_sflat
 #fflat_path = /Users/pena/Documents/PyCharmProjects/nirspec/pipeline/src/sandbox/zzzz/nirspec_MOS_fflat
-sflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.3_S_Flat/MOS/nirspec_MOS_sflat
-fflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.1_F_Flat/MOS/nirspec_MOS_fflat
-#sflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.3_S_Flat/FS/nirspec_FS_sflat
-#fflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.1_F_Flat/FS/nirspec_FS_fflat
+#sflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.3_S_Flat/MOS/nirspec_MOS_sflat
+#fflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.1_F_Flat/MOS/nirspec_MOS_fflat
+sflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.3_S_Flat/FS/nirspec_FS_sflat
+fflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.1_F_Flat/FS/nirspec_FS_fflat
 #sflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.3_S_Flat/IFU/nirspec_IFU_sflat
 #fflat_path = /grp/jwst/wit4/nirspec/CDP3/04_Flat_field/4.1_F_Flat/IFU/nirspec_IFU_fflat
 

--- a/calwebb_spec2_pytests/auxiliary_code/flattest_ifu.py
+++ b/calwebb_spec2_pytests/auxiliary_code/flattest_ifu.py
@@ -141,6 +141,9 @@ def flattest(step_input_filename, dflatref_path=None, sfile_path=None, fflat_pat
     dfimdq = np.transpose(dfimdq)
     if det == "NRS2":
         dfimdq = dfimdq[..., ::-1, ::-1]
+        # rotate science data by 180 degrees
+        dfim = np.rot90(dfim)
+        dfim = np.rot90(dfim)
     naxis3 = fits.getval(dfile, "NAXIS3", "SCI")#1)
 
     # get the wavelength values
@@ -183,6 +186,10 @@ def flattest(step_input_filename, dflatref_path=None, sfile_path=None, fflat_pat
     print("Using S-flat: ", sfile)
     sfim = fits.getdata(sfile, "SCI")#1)
     sfimdq = fits.getdata(sfile, "DQ")#3)
+    if det == "NRS2":
+        # rotate dq data by 180 degrees
+        sfimdq = np.rot90(sfimdq)
+        sfimdq = np.rot90(sfimdq)
 
     # need to flip/rotate image into science orientation
     sfim = np.transpose(sfim)

--- a/utils/level2b_hdr_keywd_dict_sample.py
+++ b/utils/level2b_hdr_keywd_dict_sample.py
@@ -323,7 +323,7 @@ keywd_dict['wcsinfo'] = {
                             'S_REGION' : 'N/A', # spatial extent of the observation, e.g. 'N/A'
                             'WAVSTART' : 1.0, # lower bound of the default wavelength range
                             'WAVEND' : 2.0, # upper bound of the default wavelength range
-                            'SPORDER' : 1.0, # default spectral order
+                            'SPORDER' : 1, # default spectral order
                             'V2_REF' : 101.1, # location of the aperture reference point in V2 (arcsec): 100-400 arcsec
                             'V3_REF' : -202.2, # location of the aperture reference point in V3 (arcsec): -100 to -400 arcsec
                             'VPARITY' : -1, # Relative sense of rotation between Ideal xy and V2V3


### PR DESCRIPTION
changes to flattest_ifu to rotate D- and S-flat science and dq extensions, respectively, for NRS2