### PR TITLE
Update pathloss_mos.py wavelength array

### DIFF
--- a/nirspec_pipe_testing_tool/calwebb_spec2_pytests/auxiliary_code/pathloss_mos.py
+++ b/nirspec_pipe_testing_tool/calwebb_spec2_pytests/auxiliary_code/pathloss_mos.py
@@ -284,7 +284,7 @@ def pathtest(step_input_filename, reffile, comparison_filename,
         # get the wavelength from the input model
         wcs_obj = slit.meta.wcs
         x, y = wcstools.grid_from_bounding_box(wcs_obj.bounding_box, step=(1, 1), center=True)
-        ra, dec, wave = slit.meta.wcs(x, y)
+        wave = slit.wavelength
         wave_sci = wave * 1.0e-6  # microns --> meters
         if debug:
             print('   wave_sci.size=', wave_sci.size, '  wave_ref.size=', wave_ref.size)


### PR DESCRIPTION
Wavelength array should include offsets from the wavelength calibration step, rather than wavelengths calculated using the WCS. See https://jira.stsci.edu/browse/JP-1698 for details.